### PR TITLE
给 peek-pop 打开的窗口添加[peek]标识，这样平铺式窗口管理器可以通过正则表达式来让peek-pop打开的窗口浮动而非平铺

### DIFF
--- a/background.js
+++ b/background.js
@@ -794,22 +794,9 @@ function createPopupWindow(trigger, linkUrl, tab, windowType, left, top, width, 
                         };
                     }
                     chrome.tabs.onUpdated.addListener(function listener(tabId, info) {
-                        if (tabId === newWindow.tabs[0].id) {
-                            if (info.status === "complete") {
-                                chrome.tabs.sendMessage(newWindow.tabs[0].id, payload);
-                            }
-                            // Add [Peek] prefix to title for window manager identification
-                            if (info.title && !info.title.startsWith('[Peek] ')) {
-                                chrome.tabs.executeScript(tabId, {
-                                    code: `document.title = '[Peek] ' + document.title;`
-                                });
-                            }
-                        }
-                    });
-                    chrome.tabs.onRemoved.addListener(function removeListener(closedTabId) {
-                        if (closedTabId === newWindow.tabs[0].id) {
+                        if (tabId === newWindow.tabs[0].id && info.status === "complete") {
+                            chrome.tabs.sendMessage(newWindow.tabs[0].id, payload);
                             chrome.tabs.onUpdated.removeListener(listener);
-                            chrome.tabs.onRemoved.removeListener(removeListener);
                         }
                     });
 

--- a/content.js
+++ b/content.js
@@ -3429,3 +3429,23 @@ window.addEventListener('blur', () => {
         document.addEventListener('scrollend', onScrollEnd);
     }
 });
+
+// Add [Peek Pop] prefix to popup window titles for tiling window manager identification
+if (window.self === window.top) {
+    chrome.runtime.sendMessage({ action: "getWindowType" }, (response) => {
+        if (chrome.runtime.lastError || !response || response.windowType !== 'popup') return;
+
+        function ensurePrefix() {
+            if (!document.title.startsWith('[Peek Pop] ')) {
+                document.title = '[Peek Pop] ' + document.title;
+            }
+        }
+
+        ensurePrefix();
+
+        const titleEl = document.querySelector('title');
+        if (titleEl) {
+            new MutationObserver(ensurePrefix).observe(titleEl, { childList: true, characterData: true, subtree: true });
+        }
+    });
+}


### PR DESCRIPTION
尤其对于Wayland下的窗口管理器而言。