### PR TITLE
fix: correct platform-specific configuration for Firefox

### DIFF
--- a/source_code/firefox/configs.js
+++ b/source_code/firefox/configs.js
@@ -72,7 +72,7 @@ export const configs = {
     'holdToPreview': false,
     'holdToPreviewTimeout': 1500,
 
-    'isFirefox': false,
+    'isFirefox': true,
     'isMac': false,
     'enableContainerIdentify': true,
 


### PR DESCRIPTION
Corrects the `isFirefox` flag in the Firefox-specific configuration object. Previously, this was incorrectly set to `false`, potentially causing platform-specific logic to behave unexpectedly on Firefox. Setting this value to `true` ensures that the extension correctly identifies the hosting environment.

### Technical Impact Analysis:
- **Logic Correctness**: Ensures that `isFirefox` accurately reflects the environment, preventing potential issues with feature branching or platform-specific API handling that relies on this flag.
- **Maintainability**: Aligns the configuration with the intended environment, reducing ambiguity in codebase behavior.